### PR TITLE
Replace document.title source to avoid title with ellipsis.

### DIFF
--- a/Tampermonkey/devops-item-updates-message-for-slack.user.js
+++ b/Tampermonkey/devops-item-updates-message-for-slack.user.js
@@ -32,7 +32,7 @@
                 priorityIcon = ':icrhigh:'
             }
 
-            GM_setClipboard(priorityIcon + " @here Updates on `" + document.title + "`\n" + window.location , 'text');
+            GM_setClipboard(priorityIcon + " @here Updates on `" + $('#vss_131').text() + "`\n" + window.location , 'text');
         });
     }, 2000);
 })();


### PR DESCRIPTION
The text from the `document.title` is limited by default. So, I replaced this source with the div identified as `$(#vss_131)` that saves the WI information. I tested in three WI and it worked well.  